### PR TITLE
Add support for Drupal 8

### DIFF
--- a/bin/check_drupal
+++ b/bin/check_drupal
@@ -191,14 +191,8 @@ is_drupal_root() {
 		return 1
 	fi
 
-	if [ ! -f "${1}/includes/bootstrap.inc" ]; then
-		return 1
-	fi
-
-	# Test for drupal constant
-	# Drupal7:   'DRUPAL_ROOT'
-	# Drupal6+7: 'DRUPAL_BOOTSTRAP_FULL'
-	if ! grep 'DRUPAL_BOOTSTRAP_FULL' "${1}/index.php" 1>/dev/null; then
+	# Use drush to test root
+	if ! drush -r "${1}" status | grep 'Drupal root' 1>/dev/null; then
 		return 1
 	fi
 	return 0


### PR DESCRIPTION
This change works for my Drupal 8 environment. I wasn't sure why you didn't use drush to check for a valid root.

I haven't tested this change against Drupal 6 or Drupal 7.
