### PR TITLE
Let check_drupal_log read from stdin

### DIFF
--- a/bin/check_drupal_log
+++ b/bin/check_drupal_log
@@ -64,6 +64,7 @@ print_version() {
 # @return integer 0
 print_usage() {
 	printf "Usage: %s -f <logfile>\n" "${INFO_NAME}"
+	printf "OR     %s -f -\n" "${INFO_NAME}"
 	printf "OR     %s --help\n" "${INFO_NAME}"
 	printf "OR     %s --version\n\n" "${INFO_NAME}"
 	return 0
@@ -80,7 +81,8 @@ print_help() {
 	# Show help and details
 	printf "Nagios plugin that will parse the logfile created by 'check_drupal'.\n\n"
 
-	printf "  -f <logfile>           The full path to logfile created by 'check_drupal'\n\n"
+	printf "  -f <logfile>           The full path to logfile created by 'check_drupal'\n"
+	printf "                         Specify '-' to read from standard input\n\n"
 
 	printf "  --help                 Show this help\n"
 	printf "  --version              Show version information.\n"

--- a/bin/check_drupal_log
+++ b/bin/check_drupal_log
@@ -26,6 +26,8 @@ EXIT_OK=0
 #EXIT_ERR=2
 EXIT_UNKNOWN=3
 
+# Need special behavior when reading from stdin
+READING_STDIN=
 
 
 ################################################################################
@@ -138,28 +140,60 @@ if [ -z "$LOGFILE" ]; then
 	exit $EXIT_UNKNOWN
 fi
 
-# Check if logfile exists
-if [ ! -f "$LOGFILE" ]; then
-	echo "[UNKNOWN] Logfile does not exist: ${LOGFILE}."
-	exit $EXIT_UNKNOWN
-fi
+# Check if logfile is stdin
+if [ "$LOGFILE" = "-" ]; then
+	READING_STDIN=1
 
-# Check if logfile is readable
-if [ ! -r "$LOGFILE" ]; then
-	echo "[UNKNOWN] Logfile is not readable: ${LOGFILE}."
-	exit $EXIT_UNKNOWN
+	# Generate random tmpfile
+	if ! command -v mktemp >/dev/null 2>&1; then
+		_rand="$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 32)"
+		LOGFILE="/tmp/.drushrc.${_rand}"
+		touch "${LOGFILE}"
+		_ret=$?
+	else
+		LOGFILE="$(mktemp)"
+		_ret=$?
+	fi
+
+	# Quit on error immediately
+	if [ ${_ret} -ne 0 ]; then
+		echo "[UNKNOWN] Can't create temporary file"
+		return $EXIT_UNKNOWN
+	fi
+
+	cat > "$LOGFILE"
+else
+	# Check if logfile exists
+	if [ ! -f "$LOGFILE" ]; then
+		echo "[UNKNOWN] Logfile does not exist: ${LOGFILE}."
+		exit $EXIT_UNKNOWN
+	fi
+
+	# Check if logfile is readable
+	if [ ! -r "$LOGFILE" ]; then
+		echo "[UNKNOWN] Logfile is not readable: ${LOGFILE}."
+		exit $EXIT_UNKNOWN
+	fi
 fi
 
 # Check if last line contains error code
 NAGIOS_EXIT="$(tail -n1 "$LOGFILE")"
 if ! isint "${NAGIOS_EXIT}" > /dev/null 2>&1 ; then
+	if [ -n "$READING_STDIN" ]; then
+		rm -f "$LOGFILE"
+	fi
 	echo "[UNKNOWN] Logfile seems invalid: Does not contain exit code on last line."
 	exit $EXIT_UNKNOWN
 fi
 
 # Check if exit code is within bounds
 if [ "$NAGIOS_EXIT" != "0" ] && [ "$NAGIOS_EXIT" != "1" ] && [ "$NAGIOS_EXIT" != "2" ]  && [ "$NAGIOS_EXIT" != "3" ]; then
-	echo "[UNKNOWN] Exit code not within bounds in $LOGFILE"
+	if [ -n "$READING_STDIN" ]; then
+		rm -f "$LOGFILE"
+		echo "[UNKNOWN] Exit code not within bounds on stdin"
+	else
+		echo "[UNKNOWN] Exit code not within bounds in $LOGFILE"
+	fi
 	exit $EXIT_UNKNOWN
 fi
 
@@ -169,6 +203,10 @@ NUM_LINES="$(wc -l < "$LOGFILE")"
 NUM_LINES="$((NUM_LINES-1))" # Last line is exit code
 
 OUTPUT="$(head -n${NUM_LINES} "$LOGFILE")"
+
+if [ -n "$READING_STDIN" ]; then
+	rm -f "$LOGFILE"
+fi
 
 echo "$OUTPUT"
 exit "$NAGIOS_EXIT"


### PR DESCRIPTION
I found myself in an awkward situation where I couldn't run NRPE or use check_by_ssh on the system hosting a Drupal instance I needed to monitor, hence this patch which allows check_drupal_log to read from stdin.

The expected use of this feature is that on the web server, a cron job will run `check_drupal_log -l /var/www/foo/cdl.txt` to dump plugin output to a text file. On the monitoring server, Nagios (or Icinga or...) picks up the content of the file and parses it by running `curl https://my.site.example.com/foo/cdl.txt | check_drupal_log -f -`