### PR TITLE
new parameter for drush from Vendor directory

### DIFF
--- a/bin/check_drupal
+++ b/bin/check_drupal
@@ -650,7 +650,7 @@ if [ "${1}" = "--check_vendor" ]; then
 		shift
 	done
 	VENDOR_DRUSH_PATH="../vendor/drush/drush/drush"
-    DRUSH="${DRUPAL_ROOT}/${VENDOR_DRUSH_PATH}"
+	DRUSH="${DRUPAL_ROOT}/${VENDOR_DRUSH_PATH}"
 	check
 	exit $EXIT_OK
 fi

--- a/bin/check_drupal
+++ b/bin/check_drupal
@@ -522,7 +522,7 @@ print_version() {
 # @output string  The requirements.
 # @return integer 0 on success, 2 on fail
 check() {
-	if command -v "{$DRUSH}" > /dev/null 2>&1; then
+	if command -v "$DRUSH" > /dev/null 2>&1; then
 		echo "[OK] drush found"
 		return "$EXIT_ERR"
 	else
@@ -616,6 +616,7 @@ print_help() {
 	printf "                         default for <drupal root>/../vendor/drush/drush/drush '\n\n"
 
 	printf "  --check                Check for program requirements.\n"
+	printf "  --check_vendor         Check for program requirements, when using vendor drush. The parameter -d <drupal root>  is required.  \n" 
 	printf "  --help                 Show this help\n"
 	printf "  --version              Show version information.\n"
 	return 0
@@ -636,6 +637,23 @@ if [ "${1}" = "--check" ]; then
 	check
 	exit $EXIT_OK
 fi
+if [ "${1}" = "--check_vendor" ]; then
+    while test -n "$1"; do
+
+		case "$1" in
+				 -d)
+                      # Get next arg in list (Path)
+                      shift
+                      DRUPAL_ROOT="$1"
+                      ;;
+		esac
+		shift
+	done
+	VENDOR_DRUSH_PATH="../vendor/drush/drush/drush"
+    DRUSH="${DRUPAL_ROOT}/${VENDOR_DRUSH_PATH}"
+	check
+	exit $EXIT_OK
+fi
 if [ "${1}" = "--help" ]; then
 	print_help
 	exit $EXIT_OK
@@ -645,16 +663,6 @@ if [ "${1}" = "--version" ]; then
 	exit $EXIT_OK
 fi
 
-
-############################################################
-# Check requirements
-############################################################
-
-# Do we have 'drush'?
-if ! command -v "${DRUSH}" > /dev/null 2>&1 ; then
-	printf "[UNKNOWN] 'drush' not found.\n"
-	exit $EXIT_UNKNOWN
-fi
 
 
 ############################################################
@@ -784,6 +792,18 @@ while test -n "$1"; do
 	esac
 	shift
 done
+
+
+############################################################
+# Check requirements
+############################################################
+
+# Do we have 'drush'?
+if ! command -v "${DRUSH}" > /dev/null 2>&1 ; then
+	printf "[UNKNOWN] 'drush' not found.\n"
+	exit $EXIT_UNKNOWN
+fi
+
 
 ############################################################
 # Validate arguments
@@ -1115,4 +1135,3 @@ fi
 
 
 # " vim: set ts=4:
-

--- a/bin/check_drupal
+++ b/bin/check_drupal
@@ -201,7 +201,7 @@ is_drupal_root() {
 	fi
 
 	# Use drush to test root
-	if ! drush -r "${1}" --uri="${2}" status | grep 'Drupal root' 1>/dev/null; then
+	if ! "${DRUSH}" -r "${1}" --uri="${2}" status | grep 'Drupal root' 1>/dev/null; then
 		return 1
 	fi
 	return 0
@@ -522,7 +522,7 @@ print_version() {
 # @output string  The requirements.
 # @return integer 0 on success, 2 on fail
 check() {
-	if command -v drush > /dev/null 2>&1; then
+	if command -v {$DRUSH} > /dev/null 2>&1; then
 		echo "[OK] drush found"
 		return "$EXIT_ERR"
 	else
@@ -535,7 +535,7 @@ check() {
 # @output string  The usage screen.
 # @return integer 0
 print_usage() {
-	printf "Usage: %s -d <drupal root> [-n <name>] [-s <w|e>] [-u <w|e>] [-e <w|e>] [-w <w|e>] [-m <w|e>] [-i <uri>] [-l <log file>] [-r]\n" "${INFO_NAME}"
+	printf "Usage: %s -d <drupal root> [-n <name>] [-s <w|e>] [-u <w|e>] [-e <w|e>] [-w <w|e>] [-m <w|e>] [-i <uri>] [-l <log file>] [-r]\n  [-v]\n" "${INFO_NAME}"
 	printf "OR     %s --check\n" "${INFO_NAME}"
 	printf "OR     %s --help\n" "${INFO_NAME}"
 	printf "OR     %s --version\n\n" "${INFO_NAME}"
@@ -612,6 +612,9 @@ print_help() {
 	printf "  -r                     [optional] Filters all updates that are locked via drush.\n"
 	printf "                         For general infos about locking run 'drush pm-updatestatus -h'\n\n"
 
+	printf "  -v                     [optional] Use Vendor Drush instead of global drush.\n"
+	printf "                         default for <drupal root>/../vendor/drush/drush/drush '\n\n"
+
 	printf "  --check                Check for program requirements.\n"
 	printf "  --help                 Show this help\n"
 	printf "  --version              Show version information.\n"
@@ -648,7 +651,7 @@ fi
 ############################################################
 
 # Do we have 'drush'?
-if ! command -v drush > /dev/null 2>&1 ; then
+if ! command -v ${DRUSH} > /dev/null 2>&1 ; then
 	printf "[UNKNOWN] 'drush' not found.\n"
 	exit $EXIT_UNKNOWN
 fi
@@ -769,6 +772,11 @@ while test -n "$1"; do
 		-r)
 			LOCK="1"
 			;;
+		-v)
+			VENDOR_DRUSH="1"
+			VENDOR_DRUSH_PATH="../vendor/drush/drush/drush"
+			DRUSH="${DRUPAL_ROOT}/${VENDOR_DRUSH_PATH}"
+			;;
 		*)
 			printf "Unknown argument: %s\n" "$1"
 			print_usage
@@ -777,15 +785,6 @@ while test -n "$1"; do
 	esac
 	shift
 done
-
-# Use a drushrc.php file to set the language to english
-if ! DRUSHRC="$(write_drushrc)"; then
-	printf "[UNKNOWN] Unable to create tmpfile\n"
-	exit $EXIT_UNKNOWN
-fi
-
-DRUSH="${DRUSH} --config=${DRUSHRC}"
-
 
 ############################################################
 # Validate arguments
@@ -822,6 +821,16 @@ if [ -n "$LOGGING" ]; then
 		fi
 	fi
 fi
+
+
+# Use a drushrc.php file to set the language to english
+if ! DRUSHRC="$(write_drushrc)"; then
+	printf "[UNKNOWN] Unable to create tmpfile\n"
+	exit $EXIT_UNKNOWN
+fi
+
+DRUSH="${DRUSH} --config=${DRUSHRC}"
+
 
 
 ############################################################

--- a/bin/check_drupal
+++ b/bin/check_drupal
@@ -38,7 +38,7 @@ fi
 #PHP_OPTS="-d intl.default_locale='en_US'"
 
 # Drush executeable
-DRUSH="$(which drush 2>/dev/null)"
+DRUSH="$(command -v drush 2>/dev/null)"
 
 
 
@@ -522,7 +522,7 @@ print_version() {
 # @output string  The requirements.
 # @return integer 0 on success, 2 on fail
 check() {
-	if command -v {$DRUSH} > /dev/null 2>&1; then
+	if command -v "{$DRUSH}" > /dev/null 2>&1; then
 		echo "[OK] drush found"
 		return "$EXIT_ERR"
 	else
@@ -651,7 +651,7 @@ fi
 ############################################################
 
 # Do we have 'drush'?
-if ! command -v ${DRUSH} > /dev/null 2>&1 ; then
+if ! command -v "${DRUSH}" > /dev/null 2>&1 ; then
 	printf "[UNKNOWN] 'drush' not found.\n"
 	exit $EXIT_UNKNOWN
 fi
@@ -773,7 +773,6 @@ while test -n "$1"; do
 			LOCK="1"
 			;;
 		-v)
-			VENDOR_DRUSH="1"
 			VENDOR_DRUSH_PATH="../vendor/drush/drush/drush"
 			DRUSH="${DRUPAL_ROOT}/${VENDOR_DRUSH_PATH}"
 			;;


### PR DESCRIPTION
Added new Parameter -v to indicate to use Vendor parameter
If -v is added as parameter /../vendor/drush/drush/drush is added to the path
default for DRUSH is then <drupal root>/../vendor/drush/drush/drush

Only problem: could not get it to run with --config param. There was an error while checking is_drupal_root_dir. Therefore I just moved that setting to after this check. 

`[preflight] Unable to parse at line 1 (near "<?php").``